### PR TITLE
Fix layout alignment on static site

### DIFF
--- a/Static_site/styles.css
+++ b/Static_site/styles.css
@@ -25,22 +25,20 @@ body, html {
 
 .container {
     display: flex;
-    min-height: 100vh;
-    padding-bottom: 60px;
-    box-sizing: border-box;
     width: 100%;
+    height: calc(100vh - 60px);
+    box-sizing: border-box;
 }
 
 .left-side {
-    width: 50%;
-    min-width: 400px;
-    flex-shrink: 0;
+    flex: 0 0 30%;
+    min-width: 300px;
     padding: 2rem;
     box-sizing: border-box;
     display: flex;
     flex-direction: column;
     height: calc(100vh - 60px);
-    overflow-y: auto;
+    overflow-y: visible;
 }
 
 .left-side::-webkit-scrollbar {
@@ -63,10 +61,8 @@ body, html {
     padding: 1rem;
     box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
     flex-grow: 1;
-    overflow-y: auto;
     display: flex;
     flex-direction: column;
-
 }
 
 .header {
@@ -95,11 +91,12 @@ body, html {
 }
 
 .right-side {
+    flex: 1;
     width: 70%;
     padding: 2rem;
     box-sizing: border-box;
-    height: 100vh; /* Full viewport height */
-    overflow-y: scroll; /* Enable scrolling */
+    height: calc(100vh - 60px);
+    overflow-y: auto;
     overflow-x: hidden;
 }
 
@@ -247,6 +244,7 @@ body, html {
     list-style-type: none;
     padding: 0;
     display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
     gap: 2rem;
 }
 
@@ -303,6 +301,7 @@ body, html {
 
 .projects-list {
     display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
     gap: 2rem;
     padding: 0;
     list-style: none;


### PR DESCRIPTION
## Summary
- adjust container to use full viewport height minus footer
- set left and right column widths so total width equals 100%
- remove extra scrolling on sidebar
- make reads and projects lists use responsive grid columns

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684355a562848323b27695aaa0311237