### PR TITLE
Fix grid alignment and remove extra scroll

### DIFF
--- a/client/src/styles/main.css
+++ b/client/src/styles/main.css
@@ -485,13 +485,14 @@ h2 {
 
 .content-section {
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
   gap: 1.5rem;
   padding: 1rem;
   width: auto;
   box-sizing: border-box;
   overflow-x: hidden;
   grid-auto-flow: row;
+  align-items: start;
 }
 
 /* Add specific styles for Nodes content */
@@ -857,8 +858,6 @@ input, textarea, button {
 
 .reads-container {
   padding: 2rem;
-  height: calc(100vh - 60px);
-  overflow-y: auto;
   box-sizing: border-box;
 }
 


### PR DESCRIPTION
## Summary
- improve content grid layout so items align
- remove fixed height/overflow from Reads container to avoid nested scrolling

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68436cbe03708323952504632549f0bd