### PR TITLE
Debug deployment errors and api issues

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: node server/index.js
+web: npm start

--- a/server/index.js
+++ b/server/index.js
@@ -11,6 +11,16 @@ const path = require('path');
 
 const app = express();
 
+// Guard against malformed URL encodings in the request path
+app.use((req, res, next) => {
+  try {
+    decodeURIComponent(req.path);
+  } catch (err) {
+    return res.status(400).send('Bad Request');
+  }
+  next();
+});
+
 const corsOptions = {
   origin: process.env.NODE_ENV === 'production' 
     ? ['https://ab-site-6hir5.ondigitalocean.app', 'https://alexbock.io']
@@ -164,6 +174,15 @@ app.use(express.static(path.join(__dirname, '../client/build')));
 // Handle React routing, return all requests to React app
 app.get('*', (req, res) => {
   res.sendFile(path.join(__dirname, '../client/build', 'index.html'));
+});
+
+// Error handling middleware
+app.use((err, req, res, next) => {
+  if (err instanceof URIError) {
+    return res.status(400).send('Bad Request');
+  }
+  console.error('Error:', err);
+  res.status(500).json({ message: 'Server error' });
 });
 
 const port = process.env.PORT || 8080;

--- a/server/server.js
+++ b/server/server.js
@@ -7,6 +7,17 @@ const app = express();
 const podcastRoutes = require('./routes/podcastRoutes');
 const readRoutes = require('./routes/readRoutes');
 
+// Guard against malformed URL encodings in the request path
+app.use((req, res, next) => {
+  try {
+    // Will throw for sequences like '/%c0' or other invalid encodings
+    decodeURIComponent(req.path);
+  } catch (err) {
+    return res.status(400).send('Bad Request');
+  }
+  next();
+});
+
 // Middleware
 app.use(cors({
   origin: process.env.NODE_ENV === 'production' 
@@ -34,6 +45,9 @@ if (process.env.NODE_ENV === 'production') {
 
 // Error handling middleware
 app.use((err, req, res, next) => {
+  if (err instanceof URIError) {
+    return res.status(400).send('Bad Request');
+  }
   console.error('Error:', err);
   res.status(500).json({ error: err.message || 'Something broke!' });
 });


### PR DESCRIPTION
Add URL decoding guards and URIError handling to prevent 400 errors from malformed paths, and update the Procfile to align with the `npm start` command.

The `URIError: Failed to decode param '/%c0'` was occurring due to Express's default URL decoding failing on malformed URL segments. This PR adds middleware to gracefully handle such requests by returning a 400 Bad Request. Additionally, the `Procfile` was updated to use `npm start` to resolve a `CNB_PROCESS_TYPE` warning and ensure consistency with the application's actual startup script.

---
<a href="https://cursor.com/background-agent?bcId=bc-e2ed566d-d4e0-49ec-8304-fd4f7a66c8ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e2ed566d-d4e0-49ec-8304-fd4f7a66c8ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

